### PR TITLE
Make changes which enable loading of old checkpoints

### DIFF
--- a/pypolygames/params.py
+++ b/pypolygames/params.py
@@ -522,7 +522,7 @@ class SimulationParams:
             yield param, arg_field
 
 
-@dataclass
+@dataclass(repr=False)
 class ExecutionParams:
     checkpoint_dir: Path = None
     save_dir: str = None  # keep for deprecation warning
@@ -540,6 +540,10 @@ class ExecutionParams:
     opponent_model_path: Path = None
     tournament_mode: bool = False
     rnn_seqlen: int = 0
+
+    def __repr__(self):
+        return f"{self.saving_period}_{self.human_first}_{self.time_ratio}_" \
+               f"{self.total_time}_{self.seed}_{self.opponent_model_path}"
 
     def __setattr__(self, attr, value):
         if value is None:

--- a/pypolygames/params.py
+++ b/pypolygames/params.py
@@ -522,7 +522,7 @@ class SimulationParams:
             yield param, arg_field
 
 
-@dataclass(repr=False)
+@dataclass
 class ExecutionParams:
     checkpoint_dir: Path = None
     save_dir: str = None  # keep for deprecation warning
@@ -540,10 +540,6 @@ class ExecutionParams:
     opponent_model_path: Path = None
     tournament_mode: bool = False
     rnn_seqlen: int = 0
-
-    def __repr__(self):
-        return f"{self.saving_period}_{self.human_first}_{self.time_ratio}_" \
-               f"{self.total_time}_{self.seed}_{self.opponent_model_path}"
 
     def __setattr__(self, attr, value):
         if value is None:

--- a/pypolygames/utils/checkpoint.py
+++ b/pypolygames/utils/checkpoint.py
@@ -24,6 +24,40 @@ from ..params import (
     ExecutionParams,
 )
 
+
+# These were added to allow for loading of old checkpoints
+import dataclasses
+import pypolygames
+import tube
+
+from typing import TypedDict
+
+
+class BufferType(TypedDict):
+    first: str
+    second: torch.Tensor
+
+@dataclasses.dataclass
+class MyReplayBuffer:
+    capacity: int
+    size: int
+    nextIdx: int
+    rngState: str
+    buffer: BufferType
+
+    def __getstate__(self):
+            pass
+
+    def __setstate__(self, x):
+        self.capacity = x[0]
+        self.size = x[1]
+        self.nextIdx = x[2]
+        self.rngState = x[3]
+        self.buffer = x[4]
+
+tube.ReplayBuffer = MyReplayBuffer
+
+
 Checkpoint = Dict[
     str,
     Union[


### PR DESCRIPTION
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

Previously when loading a checkpoint, the unpickler would look for a ReplayBuffer in `tube` but not find one, since it was moved to `core` at some point over the repo's lifetime. To get around this we just make a fake ReplayBuffer.

It's not clear whether the inclusion of the replay buffer into the checkpoint was intentional, or if they included it by mistake. It does seem like this is not properly wiring the replay buffer up to be used when training from a checkpoint, but it's also not obvious that we would want to keep the replay buffer in the first place. So it's probably fine?

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->
Both "train" and "eval" work when loading from checkpoint.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] The documentation is up-to-date with the changes I made.
- [ ] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.
