### PR TITLE
Make it possible to load in different player1 and player2 options fro…

### DIFF
--- a/pypolygames/__main__.py
+++ b/pypolygames/__main__.py
@@ -28,7 +28,7 @@ from .human import run_human_played_game
 from .human import run_tp_played_game
 from .convert import convert_checkpoint
 from .draw_model import draw_model
-from .pure_mcts import run_pure_mcts_played_game
+from .pure_mcts import run_pure_mcts_game
 
 DOC = """The python package `pypolygames` can be used in either of the following modes:
 
@@ -90,7 +90,7 @@ def parse_args() -> argparse.Namespace:
 
     # PURE MCTS
     parser_mcts = subparsers.add_parser("pure_mcts")
-    parser_mcts.set_defaults(func=run_pure_mcts_played_game_from_args)
+    parser_mcts.set_defaults(func=run_pure_mcts_game_from_args)
 
     # TRAINING
     parser_train = subparsers.add_parser("train")
@@ -405,13 +405,13 @@ def run_human_played_game_from_args(args: argparse.Namespace):
     )
 
 
-def run_pure_mcts_played_game_from_args(args: argparse.Namespace):
+def run_pure_mcts_game_from_args(args: argparse.Namespace):
     game_params = instanciate_params_from_args(GameParams, args)
     model_params = instanciate_params_from_args(ModelParams, args)
     simulation_params = instanciate_params_from_args(SimulationParams, args)
     simulation_params.num_game = 1
     execution_params = instanciate_params_from_args(ExecutionParams, args)
-    run_pure_mcts_played_game(
+    run_pure_mcts_game(
         game_params=game_params,
         model_params=model_params,
         simulation_params=simulation_params,

--- a/pypolygames/params.py
+++ b/pypolygames/params.py
@@ -358,6 +358,7 @@ class SimulationParams:
     num_threads: int = 0
     num_actor: int = 1  # should be 1 at training time
     num_rollouts: int = 1600
+    num_rollouts_2: int = 1600  # only relevant for pure_mcts mode
     replay_capacity: int = 1_000_000
     replay_warmup: int = 10_000
     sync_period: int = 100
@@ -368,8 +369,11 @@ class SimulationParams:
     rewind: int = 0
     randomized_rollouts: bool = False
     sampling_mcts: bool = False
+    sampling_mcts_2: bool = False  # only relevant for pure_mcts mode
     sample_before_step_idx: int = 30  # Why 30? Where is the default value used?
+    sample_before_step_idx_2: int = 30  # only relevant for pure_mcts mode
     smooth_mcts_sampling: bool = False
+    smooth_mcts_sampling_2: bool = False  # only relevant for pure_mcts mode
     train_channel_timeout_ms: int = 1000
     train_channel_num_slots: int = 10000
 
@@ -403,6 +407,7 @@ class SimulationParams:
                     help="Nb of act_batches the replay buffer needs to buffer " "before the training can start",
                 )
             ),
+            num_rollouts_2=ArgFields(opts=dict(type=int, help="Number of rollouts per actor/thread (opponent)")),
             sync_period=ArgFields(
                 opts=dict(
                     type=int,
@@ -456,11 +461,24 @@ class SimulationParams:
                     help="Use sampling MCTS",
                 )
             ),
+            sampling_mcts_2=ArgFields(
+                opts=dict(
+                    type=boolarg,
+                    help="Use sampling MCTS (opponent)",
+                )
+            ),
             sample_before_step_idx=ArgFields(
                 opts=dict(
                     type=int,
                     help="Before this many steps in the game, sample over moves instead "
                     " of always selecting the best move",
+                )
+            ),
+            sample_before_step_idx_2=ArgFields(
+                opts=dict(
+                    type=int,
+                    help="Before this many steps in the game, sample over moves instead "
+                    " of always selecting the best move (opponent)",
                 )
             ),
             smooth_mcts_sampling=ArgFields(
@@ -469,6 +487,14 @@ class SimulationParams:
                     help="If we sample in MCTS, do we use the (weird) smoothing or not. \
                          The smoothing appears to flatten the distribution, and makes it \
                          possible to sample things with zero probability",
+                )
+            ),
+            smooth_mcts_sampling_2=ArgFields(
+                opts=dict(
+                    type=bool,
+                    help="If we sample in MCTS, do we use the (weird) smoothing or not. \
+                         The smoothing appears to flatten the distribution, and makes it \
+                         possible to sample things with zero probability (opponent)",
                 )
             ),
             train_channel_timeout_ms=ArgFields(

--- a/pypolygames/pure_mcts.py
+++ b/pypolygames/pure_mcts.py
@@ -32,14 +32,6 @@ def create_pure_mcts_environment(
     game_params: GameParams,
     simulation_params: SimulationParams,
     execution_params: ExecutionParams,
-    player_1_rollouts: int = 100,
-    player_2_rollouts: int = 1000,
-    player_1_sample: bool = False,
-    player_2_sample: bool = False,
-    player_1_smooth: bool = False,
-    player_2_smooth: bool = False,
-    player_1_sample_before_step_idx: int = 80,
-    player_2_sample_before_step_idx: int = 80,
 ) -> Tuple[tube.Context, Optional[tube.DataChannel], Callable[[], int]]:
     human_first = execution_params.human_first
     actor_channel = None


### PR DESCRIPTION
…m the command line for pure_mcts

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context / Related issue

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
Previously, it was not possible to specify different simulation params for player 1 and player 2, except as implemented for a couple of things in the `eval` mode.

This change brings a `_2` option – which sets the opponent value, as opposed to the "first person" agent value – to several different hparams:
- num_rollouts
- sampling_mcts
- smooth_mcts_sampling
- sample_before_step_idx

These are useful for understanding the effects of these different things on evaluation.

Note that this is NOT yet supported for training or eval modes, ONLY for pure_mcts mode.

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->
I ran 

```python -m pypolygames pure_mcts --game_name Hex3 --sample_before_step_idx 0 --num_rollouts_2 0```

and it seemed to do what I expected.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] The documentation is up-to-date with the changes I made.
- [ ] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.
